### PR TITLE
Make BreadCrumb#setButtons remove existing buttons first

### DIFF
--- a/src/main/java/javafx/plus/component/breadcrumb/BreadCrumb.java
+++ b/src/main/java/javafx/plus/component/breadcrumb/BreadCrumb.java
@@ -121,9 +121,15 @@ public class BreadCrumb extends HBox {
     }
 
     public void setButtons(Button ... buttons) {
+        clearButtons();
         for(Button b : buttons) {
             this.addButton(b);
         }
+    }
+
+    public void clearButtons() {
+        this.currentButton.set(null);
+        super.getChildren().clear();
     }
 
     public void setSeparatorFactory(SeparatorFactory separatorFactory) {


### PR DESCRIPTION
The implementation of `BreadCrumb#setButtons` was the same as `BreadCrumb#addButtons`, as it didn't replace the existing buttons with the new buttons, but just added the new buttons to the existing buttons.
This commit fixes this and introduces the expected behaviour.